### PR TITLE
Fixed bug in recursive file deletion.

### DIFF
--- a/Deployment/libs/Ftp.php
+++ b/Deployment/libs/Ftp.php
@@ -213,7 +213,7 @@ class Ftp
 			return;
 		}
 		foreach ((array) $this->nlist($path) as $file) {
-			if ($file !== '.' && $file !== '..') {
+			if ($file !== '.' && $file !== '..' && !preg_match('#/\\.{1,2}$#', $file)) {
 				$this->deleteRecursive(strpos($file, '/') === FALSE ? "$path/$file" : $file);
 			}
 		}


### PR DESCRIPTION
Hi David. I've found (and fixed) a bug in FTP.php.

My FTP server returned the whole relative path (not just a filename) as a result of $this->nlist(). The recursive deletion tests if the returned string != '.' or '..', which never comes true when a path is returned. 

But this obviously causes infinite recursion, eg.:
myDir   (try to delete myDir)
myDir/..   (myDir/.. is the first file returned by nlist() )
myDir
myDir/..

I've also implemented per-site configuration of used CSS and JS filters. Furthermore, I've made it possible to encode the FTP site password using a 'master password' in order not to store plaintext passwords on the disk. You can have a look at those features in my fork...
