### PR TITLE
FtpServer: fixed for root directory (Closes #44)

### DIFF
--- a/Deployment/libs/FtpServer.php
+++ b/Deployment/libs/FtpServer.php
@@ -179,7 +179,7 @@ class FtpServer implements Server
 			$this->ftp('chdir', $dir);
 		} catch (FtpException $e) {
 		}
-		$this->ftp('chdir', $current);
+		$this->ftp('chdir', $current ?: '/');
 		return empty($e);
 	}
 


### PR DESCRIPTION
Related #44 

Hotfix for cases when upload targets root directory.
It was failing before bacause `ftp_chdir` trigers "Invalid number of arguments" when second argument is set but is empty (wtf).

I can't try `SshServer` if there is all OK at the moment.

Also, this fix is maybe ugly, but otherwise it will be necessary do changes in [more files](https://github.com/dg/ftp-deployment/issues/44#issuecomment-70153543)