### PR TITLE
reduce I/O and deployment time by ~48%

### DIFF
--- a/src/Deployment/Deployer.php
+++ b/src/Deployment/Deployer.php
@@ -309,9 +309,6 @@ class Deployer
 			if ($entry == '.' || $entry == '..') {
 				continue;
 
-			} elseif (!is_readable($path)) {
-				continue;
-
 			} elseif ($this->matchMask($short, $this->ignoreMasks, is_dir($path))) {
 				$this->logger->log(str_pad("Ignoring .$short", 40), 'gray');
 				continue;
@@ -336,18 +333,17 @@ class Deployer
 	 */
 	private function preprocess($file)
 	{
-		$path = realpath($file);
-		$ext = pathinfo($path, PATHINFO_EXTENSION);
+		$ext = pathinfo($file, PATHINFO_EXTENSION);
 		if (!isset($this->filters[$ext]) || !$this->matchMask($file, $this->preprocessMasks)) {
-			return $path;
+			return $file;
 		}
 
-		$content = file_get_contents($path);
+		$content = file_get_contents($file);
 		foreach ($this->filters[$ext] as $info) {
 			if ($info['cached'] && is_file($tempFile = $this->tempDir . '/' . md5($content))) {
 				$content = file_get_contents($tempFile);
 			} else {
-				$content = call_user_func($info['filter'], $content, $path);
+				$content = call_user_func($info['filter'], $content, $file);
 				if ($info['cached']) {
 					file_put_contents($tempFile, $content);
 				}

--- a/src/Deployment/SshServer.php
+++ b/src/Deployment/SshServer.php
@@ -53,9 +53,9 @@ class SshServer implements Server
 			$parts = parse_url($this->url);
 			$this->connection = ssh2_connect($parts['host'], empty($parts['port']) ? 22 : (int) $parts['port']);
 			if (isset($parts['pass'])) {
-				ssh2_auth_password($this->connection, $parts['user'], $parts['pass']);
+				ssh2_auth_password($this->connection, urldecode($parts['user']), urldecode($parts['pass']));
 			} else {
-				ssh2_auth_agent($this->connection, $parts['user']);
+				ssh2_auth_agent($this->connection, urldecode($parts['user']));
 			}
 			$this->sftp = ssh2_sftp($this->connection);
 		});


### PR DESCRIPTION
is_readable in my opinion is not needed as we should presume we will be deploying from a readable sources.
the realpath() there is not necessary, and removing it will save us a lot of I/O.
profiled it with blackfire, an opencart was deployed by 48% faster, reducing the deployment time by 53 seconds, just by making these two changes.
https://blackfire.io/profiles/compare/5c8d40e2-2b72-423f-967a-918c7e7e9c29/graph