### PR TITLE
"afterupload" command support added

### DIFF
--- a/deployment.sample.ini
+++ b/deployment.sample.ini
@@ -26,7 +26,10 @@ allowdelete = yes
 ; jobs to run before file upload
 before[] = http://example.com/deployment.php?before
 
-; jobs to run after file upload
+; jobs to run immediately after file upload
+afterupload[] = http://example.com/deployment.php?afterUpload
+
+; jobs to run after everything is done
 after[] = http://example.com/deployment.php?after
 
 ; directories to purge after file upload

--- a/deployment.sample.php
+++ b/deployment.sample.php
@@ -19,6 +19,9 @@ return [
 				$logger->log('Hello!');
 			},
 		],
+		'afterupload' => [
+			'http://example.com/deployment.php?afterUpload'
+		],
 		'after' => [
 			'http://example.com/deployment.php?after'
 		],

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,10 @@ allowdelete = yes
 before[] = local: lessc assets/combined.less assets/combined.css
 before[] = http://example.com/deployment.php?before
 
-; jobs to run after file upload
+; jobs to run immediately after file upload
+afterupload[] = http://example.com/deployment.php?afterUpload
+
+; jobs to run after everything is done
 after[] = remote: unzip api.zip
 after[] = http://example.com/deployment.php?after
 
@@ -97,8 +100,8 @@ data/* - ignore everything inside the 'data' folder, but the folder will be crea
 project.pp[jx] - ignore files or folders 'project.ppj' and 'project.ppx'
 ```
 
-Before the upload starts and after it finishes, you can execute commands or call your scripts on
-the server (see `before` and `after`), which can, for example, switch the server to a maintenance mode.
+Before the upload starts, after it finishes and after all jobs, you can execute commands or call your scripts on
+the server (see `before`, `afterupload`, `after`), which can, for example, switch the server to a maintenance mode.
 If you use php-config - you can run lambda function with deployment environment.
 
 Syncing a large number of files attempts to run in (something like) a transaction: all files are

--- a/src/Deployment/CliRunner.php
+++ b/src/Deployment/CliRunner.php
@@ -24,6 +24,7 @@ class CliRunner
 		'allowdelete' => TRUE,
 		'purge' => '',
 		'before' => '',
+		'afterupload' => '',
 		'after' => '',
 		'preprocess' => TRUE,
 	];
@@ -143,6 +144,7 @@ class CliRunner
 		$deployment->allowDelete = $config['allowdelete'];
 		$deployment->toPurge = self::toArray($config['purge'], TRUE);
 		$deployment->runBefore = self::toArray($config['before'], TRUE);
+		$deployment->runAfterUpload = self::toArray($config['afterupload'], TRUE);
 		$deployment->runAfter = self::toArray($config['after'], TRUE);
 		$deployment->testMode = !empty($config['test']) || $this->mode === 'test';
 

--- a/src/Deployment/Deployer.php
+++ b/src/Deployment/Deployer.php
@@ -37,6 +37,9 @@ class Deployer
 	public $runBefore;
 
 	/** @var array of string|callable */
+	public $runAfterUpload;
+
+	/** @var array of string|callable */
 	public $runAfter;
 
 	/** @var string */
@@ -260,9 +263,25 @@ class Deployer
 			$this->writeProgress($num + 1, count($paths), $path, NULL, 'green');
 		}
 
+		if ($this->runAfterUpload) {
+			$this->logger->log("\nAfter-upload-jobs:");
+			$this->runJobs($this->runAfterUpload);
+		}
+
+		$this->renameFiles($toRename);
+	}
+
+
+	/**
+	 * Renames uploaded files.
+	 * @param  string[]  relative paths, starts with /
+	 * @return void
+	 */
+	private function renameFiles(array $files)
+	{
 		$this->logger->log("\nRenaming:");
-		foreach ($toRename as $num => $path) {
-			$this->writeProgress($num + 1, count($toRename), "Renaming $path", NULL, 'olive');
+		foreach ($files as $num => $path) {
+			$this->writeProgress($num + 1, count($files), "Renaming $path", NULL, 'olive');
 			$this->server->renameFile($path . self::TEMPORARY_SUFFIX, $path);
 		}
 	}


### PR DESCRIPTION
When we deploy, we want switch an application to "maintenance" state.

It can be done with `before` jobs now.

But `before` means really before. Before all actions. So an application is switched to "maintenance" state and then files are being uploaded, renamed and after all, the `after` command removed "maintenance" state.

Upload may take a lot of time. And whole the time, the application is in maintenace state. Unnecessarily.

So I've added `afterupload` command support.

It's triggered immediatelly after files are uploaded and just before they are renamed.

What do you think, is it OK and useful?

What about events naming? Maybe they're confusing now, but when I rename them, it'll be a BC-break :(
