### PR TITLE
Correctly restore previous error handler

### DIFF
--- a/src/Deployment/FtpServer.php
+++ b/src/Deployment/FtpServer.php
@@ -269,8 +269,7 @@ class FtpServer implements Server
 
 	private function protect(callable $func, $args = [])
 	{
-		set_error_handler(function($severity, $message) {
-			restore_error_handler();
+		$ftpExceptionErrorHandler = function($severity, $message) {
 			if (ini_get('html_errors')) {
 				$message = html_entity_decode(strip_tags($message));
 			}
@@ -278,10 +277,25 @@ class FtpServer implements Server
 				$message = $m[1];
 			}
 			throw new FtpException($message);
-		});
-		$res = call_user_func_array($func, $args);
+		};
+
+		set_error_handler($ftpExceptionErrorHandler);
+
+		// It's ugly code bellow due to PHP 5.4 compatibility.
+		// for PHP >= 5.5, 'finally' construct is a cleaner way.
+		try {
+			$return = call_user_func_array($func, $args);
+		} catch (\Exception $e) {
+			$return = $e;
+		}
+
 		restore_error_handler();
-		return $res;
+
+		if ($return instanceof \Exception) {
+			throw $return;
+		}
+
+		return $return;
 	}
 
 }


### PR DESCRIPTION
When I run incriminated "error to exception wrapper" and then catch given Exception in a flow later, the custom error handler is still active and catches all the warnings.

It should be removed all the time - should be active only in the wrapper (`::protect` function).

It looks like that `restore_error_handler()` not working inside another error handler.

"Tested" on PHP 7.0.3 but I think the behavior is same in 5.5 but not sure.