### PR TITLE
Configurable file permissions

### DIFF
--- a/deployment.sample.ini
+++ b/deployment.sample.ini
@@ -40,3 +40,13 @@ preprocess = no
 
 ; file which contains hashes of all uploaded files (defaults to .htdeployment)
 deploymentFile = .deployment
+
+; default permissions for new files
+;fileperms = 0644
+
+; default permissions for new directories
+;dirperms = 0755
+
+; different permissions
+;chmod[] = cache:0777
+;chmod[] = folder/file.txt:066

--- a/src/Deployment/CliRunner.php
+++ b/src/Deployment/CliRunner.php
@@ -140,6 +140,9 @@ class CliRunner
 		$deployment->runAfterUpload = self::toArray($config['afterupload'], TRUE);
 		$deployment->runAfter = self::toArray($config['after'], TRUE);
 		$deployment->testMode = !empty($config['test']) || $this->mode === 'test';
+		$deployment->filePerms =  empty($config['filePerms']) ? '' : $config['fileperms'];
+		$deployment->dirPerms = empty($config['dirPerms']) ? '' : $config['dirperms'];
+		$deployment->toChmod = empty($config['chmod']) ? [] : self::toArray($config['chmod'], TRUE);
 
 		return $deployment;
 	}

--- a/src/Deployment/Deployer.php
+++ b/src/Deployment/Deployer.php
@@ -61,7 +61,14 @@ class Deployer
 	/** @var Server */
 	private $server;
 
+	/** @var string */
+	public $filePerms = '';
 
+	/** @var string */
+	public $dirPerms = '';
+
+	/** @var array */
+	public $toChmod;
 
 	/**
 	 * @param  Server
@@ -159,6 +166,12 @@ class Deployer
 			$this->deletePaths($toDelete);
 		}
 
+		foreach ((array) $this->toChmod as $chmod) {
+			list($path, $perms) = explode(':', $chmod);
+			$this->logger->log("\nChmod $path $perms");
+			$this->server->chmod($this->remoteDir . '/' . $path, $perms);
+		}
+
 		foreach ((array) $this->toPurge as $path) {
 			$this->logger->log("\nCleaning $path");
 			$this->server->purge($this->remoteDir . '/' . $path, function ($path) {
@@ -248,6 +261,9 @@ class Deployer
 			if ($remoteDir !== $prevDir) {
 				$prevDir = $remoteDir;
 				$this->server->createDir($remoteDir);
+				if ($this->dirPerms !== '') {
+					$this->server->chmod($remoteDir, $this->dirPerms);
+				}
 			}
 
 			if ($isDir) {
@@ -263,6 +279,9 @@ class Deployer
 			$this->server->writeFile($localFile, $remotePath . self::TEMPORARY_SUFFIX, function ($percent) use ($num, $paths, $path) {
 				$this->writeProgress($num + 1, count($paths), $path, $percent, 'green');
 			});
+			if ($this->filePerms !== '') {
+				$this->server->chmod($remotePath . self::TEMPORARY_SUFFIX, $this->filePerms);
+			}
 			$this->writeProgress($num + 1, count($paths), $path, NULL, 'green');
 		}
 	}

--- a/src/Deployment/FtpServer.php
+++ b/src/Deployment/FtpServer.php
@@ -109,6 +109,16 @@ class FtpServer implements Server
 		}
 	}
 
+	/**
+	 * @param string $remote
+	 * @param $perms permissions
+	 * @return void
+	 */
+	public function chmod($remote, $perms)
+	{
+		$mode = octdec(str_pad((int)$perms, 4, '0', STR_PAD_LEFT));
+		$this->ftp('chmod', $mode, $remote);
+	}
 
 	/**
 	 * Removes file from FTP server if exists.

--- a/src/Deployment/SshServer.php
+++ b/src/Deployment/SshServer.php
@@ -88,6 +88,16 @@ class SshServer implements Server
 		});
 	}
 
+	/**
+	 * @param string $remote
+	 * @param $perms permissions
+	 * @return void
+	 */
+	public function chmod($remote, $perms)
+	{
+		$mode = octdec(str_pad((int)$perms, 4, '0', STR_PAD_LEFT));
+		$this->protect('ssh2_sftp_chmod', [$this->sftp, $remote, $mode]);
+	}
 
 	/**
 	 * Removes file from FTP server if exists.

--- a/tests/Helpers.fetchUrl.phpt
+++ b/tests/Helpers.fetchUrl.phpt
@@ -16,4 +16,4 @@ if (extension_loaded('curl')) {
 } else {
 	Assert::same('', $output);
 }
-Assert::contains('404', $error);
+Assert::contains('500', $error);


### PR DESCRIPTION
Hi David, thanks for smarty tool.

I found some problems with file permissions:
1.  when I upload files from windows machine to some servers, created files/folders have permissions 0640/0750. It is a problem, because these files are not readable through webserver.
2. Some folders/files requires different permissions, i.e.  cache folder must be writable.

So, there is my solution. 

