### PR TITLE
Add Log entry when expanding files within the Preprocessor.

### DIFF
--- a/src/Deployment/Preprocessor.php
+++ b/src/Deployment/Preprocessor.php
@@ -139,13 +139,13 @@ class Preprocessor
 		$dir = dirname($origFile);
 		return preg_replace_callback('~<!--#include\s+file="(.+)"\s+-->~U', function ($m) use ($dir) {
 			$file = $dir . '/' . $m[1];
-            if (!is_file($file)) {
+			if (!is_file($file)) {
 				$this->logger->log("Expanding file $file not found!", 'red');
 				return $m[0];
 			}
 
-            $this->logger->log("Including $file");
-            return $this->expandApacheImports(file_get_contents($file), dirname($file));
+			$this->logger->log("Including $file");
+			return $this->expandApacheImports(file_get_contents($file), dirname($file));
 		}, $content);
 	}
 

--- a/src/Deployment/Preprocessor.php
+++ b/src/Deployment/Preprocessor.php
@@ -143,9 +143,9 @@ class Preprocessor
 				$this->logger->log("Expanding file $file not found!", 'red');
 				return $m[0];
 			}
-            
+
             $this->logger->log("Including $file");
-            return $this->expandApacheImports(file_get_contents($file), dirname($file));			
+            return $this->expandApacheImports(file_get_contents($file), dirname($file));
 		}, $content);
 	}
 

--- a/src/Deployment/Preprocessor.php
+++ b/src/Deployment/Preprocessor.php
@@ -110,9 +110,11 @@ class Preprocessor
 		return preg_replace_callback('#@import\s+(?:url)?[(\'"]+(.+)[)\'"]+;#U', function ($m) use ($dir) {
 			$file = $dir . '/' . $m[1];
 			if (!is_file($file)) {
+				$this->logger->log("Expanding file $file not found!", 'red');
 				return $m[0];
 			}
 
+			$this->logger->log("Including $file");
 			$s = file_get_contents($file);
 			$newDir = dirname($file);
 			$s = $this->expandCssImports($s, $file);
@@ -137,10 +139,13 @@ class Preprocessor
 		$dir = dirname($origFile);
 		return preg_replace_callback('~<!--#include\s+file="(.+)"\s+-->~U', function ($m) use ($dir) {
 			$file = $dir . '/' . $m[1];
-			if (is_file($file)) {
-				return $this->expandApacheImports(file_get_contents($file), dirname($file));
+            if (!is_file($file)) {
+				$this->logger->log("Expanding file $file not found!", 'red');
+				return $m[0];
 			}
-			return $m[0];
+            
+            $this->logger->log("Including $file");
+            return $this->expandApacheImports(file_get_contents($file), dirname($file));			
 		}, $content);
 	}
 

--- a/src/Deployment/Preprocessor.php
+++ b/src/Deployment/Preprocessor.php
@@ -145,7 +145,7 @@ class Preprocessor
 			}
 
 			$this->logger->log("Including $file");
-			return $this->expandApacheImports(file_get_contents($file), dirname($file));
+			return $this->expandApacheImports(file_get_contents($file), $file);
 		}, $content);
 	}
 


### PR DESCRIPTION
Add Log entry when expanding files within the Preprocessor.

- New feature
- BC break: no

When a CSS file contains an `@import` directive or a JS file contains a `#include` directive,it will be nice to output informations when expanding within the Preprocessor.

For example for JS:
```php
public function expandApacheImports(string $content, string $origFile): string
    ...
    if (is_file($file)) {
        $this->logger->log("Expanding $file");
        ...
    }
    $this->logger->log("Expanding file $file not found!", 'red');
    ...
```
So, we can check if an error occurs while deploying files.