### PR TITLE
Add USERAGENT for curl

### DIFF
--- a/src/Deployment/Helpers.php
+++ b/src/Deployment/Helpers.php
@@ -85,6 +85,7 @@ class Helpers
 			$options = [
 				CURLOPT_RETURNTRANSFER => 1,
 				CURLOPT_FOLLOWLOCATION => 1,
+				CURLOPT_USERAGENT => "Mozilla/5.0 (Windows NT 6.1; rv:19.0) Gecko/20100101 Firefox/19.0"
 			];
 			if ($postData !== null) {
 				$options[CURLOPT_POST] = true;


### PR DESCRIPTION
Patch error 403 from website
When using a remote link, you can get a 403 error

- bug fix / new feature?   <!-- #issue numbers, if any -->
- BC break? yes/no

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works.

Thanks for contributing!
-->
