### PR TITLE
add support for using a RSA key

### DIFF
--- a/src/Deployment/PhpsecServer.php
+++ b/src/Deployment/PhpsecServer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Deployment;
 
+use phpseclib\Crypt\RSA;
 use phpseclib\Net\SFTP;
 
 class PhpsecServer implements Server
@@ -52,8 +53,21 @@ class PhpsecServer implements Server
 			$this->sftp->disconnect(); // @ may fail
 		}
 		$sftp = new SFTP($this->url['host'], $this->url['port'] ?? 22);
-		if (!$sftp->login(urldecode($this->url['user']), urldecode($this->url['pass']))) {
-			exit('Login Failed');
+		if (!$this->privateKey !== null) {
+			$rsa = new RSA();
+			if ($this->passPhrase) {
+				$rsa->setPassword($this->passPhrase);
+			}
+			if (!$rsa->loadKey(file_get_contents($this->privateKey))) {
+				exit('Loading private key failed');
+			}
+			if (!$sftp->login(urldecode($this->url['user']), $rsa)) {
+				exit('Login Failed');
+			}
+		} else {
+			if (!$sftp->login(urldecode($this->url['user']), urldecode($this->url['pass']))) {
+				exit('Login Failed');
+			}
 		}
 		$this->sftp = $sftp;
 	}

--- a/src/Deployment/PhpsecServer.php
+++ b/src/Deployment/PhpsecServer.php
@@ -53,7 +53,7 @@ class PhpsecServer implements Server
 			$this->sftp->disconnect(); // @ may fail
 		}
 		$sftp = new SFTP($this->url['host'], $this->url['port'] ?? 22);
-		if (!$this->privateKey !== null) {
+		if ($this->privateKey) {
 			$rsa = new RSA();
 			if ($this->passPhrase) {
 				$rsa->setPassword($this->passPhrase);


### PR DESCRIPTION
- bug fix / new feature?   new feature
- BC break? no

keys generated by `ssh-keygen -t rsa` are working (with and without passphrase), other types maybe not supported (depends on the capabilities of https://github.com/phpseclib/phpseclib)
