### PR TITLE
typo

### DIFF
--- a/src/Deployment/Logger.php
+++ b/src/Deployment/Logger.php
@@ -16,7 +16,7 @@ namespace Deployment;
  */
 class Logger
 {
-	public bool $useColors;
+	public bool $useColors = false;
 
 	public bool $showProgress = true;
 


### PR DESCRIPTION
- bug fix
- BC break? no

When started deployment without config like this `php deployment -t`, it fails with error:
```
Fatal error: Uncaught Error: Typed property Deployment\Logger::$useColors must not be accessed before initialization in deployment/src/Deployment/Logger.php:72
```
