### PR TITLE
Added option to Ignore certs for run jobs

### DIFF
--- a/src/Deployment/CliRunner.php
+++ b/src/Deployment/CliRunner.php
@@ -75,6 +75,7 @@ class CliRunner
 
 			$deployment = $this->createDeployer($batch);
 			$deployment->tempDir = $tempDir;
+            $deployment->ignoreCert = $config['ignoreCert'];
 
 			if ($this->mode === 'generate') {
 				$this->logger->log('Scanning files');
@@ -259,6 +260,10 @@ class CliRunner
 		$this->batches = isset($config['remote']) && is_string($config['remote'])
 			? ['' => $config]
 			: array_filter($config, 'is_array');
+
+        if (isset($config['ignoreCert']) === false || is_bool($config['ignoreCert']) === false) {
+            $config['ignoreCert'] = false;
+        }
 
 		if (isset($options['--section'])) {
 			$section = $options['--section'];

--- a/src/Deployment/CliRunner.php
+++ b/src/Deployment/CliRunner.php
@@ -230,6 +230,7 @@ class CliRunner
 					--section <name>  Only deploys the named section.
 					--generate        Only generates deployment file.
 					--no-progress     Hide the progress indicators.
+					--ignore-cert     Ignores certificate validity on https job run.
 
 				XX,
 			[
@@ -263,6 +264,9 @@ class CliRunner
 
         if (isset($config['ignoreCert']) === false || is_bool($config['ignoreCert']) === false) {
             $config['ignoreCert'] = false;
+        }
+        if (isset($options['--ignore-cert'])) {
+            $config['ignoreCert'] = true;
         }
 
 		if (isset($options['--section'])) {

--- a/src/Deployment/CliRunner.php
+++ b/src/Deployment/CliRunner.php
@@ -75,7 +75,7 @@ class CliRunner
 
 			$deployment = $this->createDeployer($batch);
 			$deployment->tempDir = $tempDir;
-            $deployment->ignoreCert = $config['ignoreCert'];
+            $deployment->ignoreCert = $config['ignorecert'];
 
 			if ($this->mode === 'generate') {
 				$this->logger->log('Scanning files');

--- a/src/Deployment/Deployer.php
+++ b/src/Deployment/Deployer.php
@@ -30,6 +30,8 @@ class Deployer
 
 	public bool $allowDelete = false;
 
+	public bool $ignoreCert = false;
+
 	/** @var string[] relative paths */
 	public array $toPurge = [];
 
@@ -425,7 +427,7 @@ class Deployer
 				$this->logger->log($job);
 				$method = $m[1];
 				if ($method === 'http' || $method === 'https') {
-					[$out, $err] = $runner->http($m[0]);
+					[$out, $err] = $runner->http($m[0], $this->ignoreCert);
 				} else {
 					[$out, $err] = $runner->$method($m[2]);
 				}

--- a/src/Deployment/Deployer.php
+++ b/src/Deployment/Deployer.php
@@ -427,6 +427,9 @@ class Deployer
 				$this->logger->log($job);
 				$method = $m[1];
 				if ($method === 'http' || $method === 'https') {
+                    if ($this->ignoreCert === true) {
+                        $this->logger->log('[Ignoring certificate validity]', 'yellow');
+                    }
 					[$out, $err] = $runner->http($m[0], $this->ignoreCert);
 				} else {
 					[$out, $err] = $runner->$method($m[2]);

--- a/src/Deployment/Helpers.php
+++ b/src/Deployment/Helpers.php
@@ -77,7 +77,7 @@ class Helpers
 	/**
 	 * Processes HTTP request.
 	 */
-	public static function fetchUrl(string $url, ?string &$error, array $postData = null): string
+	public static function fetchUrl(string $url, ?string &$error, array $postData = null, bool $ignoreCert = false): string
 	{
 		if (extension_loaded('curl')) {
 			$ch = curl_init($url);
@@ -86,6 +86,10 @@ class Helpers
 				CURLOPT_FOLLOWLOCATION => 1,
 				CURLOPT_USERAGENT => 'Mozilla/5.0 FTP-deployment',
 			];
+            if ($ignoreCert === true) {
+                $options[CURLOPT_SSL_VERIFYPEER] = false;
+                $options[CURLOPT_SSL_VERIFYHOST] = false;
+            }
 			if ($postData !== null) {
 				$options[CURLOPT_POST] = true;
 				$options[CURLOPT_POSTFIELDS] = http_build_query($postData, '', '&');

--- a/src/Deployment/JobRunner.php
+++ b/src/Deployment/JobRunner.php
@@ -89,9 +89,9 @@ class JobRunner
 	}
 
 
-	public function http(string $url): array
+	public function http(string $url, bool $ignoreCert = false): array
 	{
-		$out = Helpers::fetchUrl($url, $err);
+		$out = Helpers::fetchUrl($url, $err, null, $ignoreCert);
 		return [$out, $err];
 	}
 }


### PR DESCRIPTION
- new feature
- BC break? no

Added option to Ignore certs for run jobs.
This option can be added in PHP settings:
```php
<?php

return [
	'remote' => 'ftp://user:secretpassword@ftp.example.com/directory',
	'local' => '.',
        'ignoreCert' => true, //Default is false

	...
];
```

Or as command line argument `--ignore-cert`

CLI argument has higher level than PHP option.