### PR TITLE
fix: #163 - permissions should not be set for FileServer

### DIFF
--- a/src/Deployment/CliRunner.php
+++ b/src/Deployment/CliRunner.php
@@ -134,12 +134,18 @@ class CliRunner
 		} else {
 			$server = new FtpServer(Helpers::buildUrl($urlParts), (bool) $config['passivemode']);
 		}
-		$server->filePermissions = empty($config['filepermissions'])
-			? null
-			: octdec($config['filepermissions']);
-		$server->dirPermissions = empty($config['dirpermissions'])
-			? null
-			: octdec($config['dirpermissions']);
+		
+		if(property_exists($server,'filePermissions')){
+			$server->filePermissions = empty($config['filepermissions'])
+				? null
+				: octdec($config['filepermissions']);
+		}
+
+		if(property_exists($server,'dirPermissions')){
+			$server->dirPermissions = empty($config['dirpermissions'])
+				? null
+				: octdec($config['dirpermissions']);
+		}
 
 		$server = new RetryServer($server, $this->logger);
 


### PR DESCRIPTION
- bug fix: #163
- BC break? no

file:// deployments are not setting unix/linux permissions and the attributes are currently not present in the FileServer class, so those attributes should not be set in the CLIRunner.
