### PR TITLE
Fix PHP 8.4 syntax

### DIFF
--- a/src/Deployment/CommandLine.php
+++ b/src/Deployment/CommandLine.php
@@ -67,7 +67,7 @@ class CommandLine
 	}
 
 
-	public function parse(array $args = null): array
+	public function parse(?array $args = null): array
 	{
 		if ($args === null) {
 			$args = isset($_SERVER['argv']) ? array_slice($_SERVER['argv'], 1) : [];

--- a/src/Deployment/Deployer.php
+++ b/src/Deployment/Deployer.php
@@ -446,8 +446,8 @@ class Deployer
 		int $count,
 		int $total,
 		string $path,
-		float $percent = null,
-		string $color = null,
+		?float $percent = null,
+		?string $color = null,
 	): void
 	{
 		$len = strlen((string) $total);

--- a/src/Deployment/FileServer.php
+++ b/src/Deployment/FileServer.php
@@ -58,7 +58,7 @@ class FileServer implements Server
 	 * Uploads file.
 	 * @throws ServerException
 	 */
-	public function writeFile(string $local, string $remote, callable $progress = null): void
+	public function writeFile(string $local, string $remote, ?callable $progress = null): void
 	{
 		Safe::copy($local, $this->root . $remote);
 		if ($this->filePermissions) {
@@ -117,7 +117,7 @@ class FileServer implements Server
 	 * Recursive deletes content of directory or file.
 	 * @throws ServerException
 	 */
-	public function purge(string $dir, callable $progress = null): void
+	public function purge(string $dir, ?callable $progress = null): void
 	{
 		$dir = $this->root . $dir;
 		if (!file_exists($dir)) {

--- a/src/Deployment/FtpServer.php
+++ b/src/Deployment/FtpServer.php
@@ -106,7 +106,7 @@ class FtpServer implements Server
 	 * Uploads file to FTP server.
 	 * @throws ServerException
 	 */
-	public function writeFile(string $local, string $remote, callable $progress = null): void
+	public function writeFile(string $local, string $remote, ?callable $progress = null): void
 	{
 		$size = max(filesize($local), 1);
 		$blocks = 0;
@@ -222,7 +222,7 @@ class FtpServer implements Server
 	 * Recursive deletes content of directory or file.
 	 * @throws ServerException
 	 */
-	public function purge(string $dir, callable $progress = null): void
+	public function purge(string $dir, ?callable $progress = null): void
 	{
 		if (!$this->isDir($dir)) {
 			return;

--- a/src/Deployment/Helpers.php
+++ b/src/Deployment/Helpers.php
@@ -77,7 +77,7 @@ class Helpers
 	/**
 	 * Processes HTTP request.
 	 */
-	public static function fetchUrl(string $url, ?string &$error, array $postData = null): string
+	public static function fetchUrl(string $url, ?string &$error, ?array $postData = null): string
 	{
 		if (extension_loaded('curl')) {
 			$ch = curl_init($url);

--- a/src/Deployment/Logger.php
+++ b/src/Deployment/Logger.php
@@ -47,7 +47,7 @@ class Logger
 	}
 
 
-	public function log(string $s, string $color = null, int $shorten = 1): void
+	public function log(string $s, ?string $color = null, int $shorten = 1): void
 	{
 		fwrite($this->file, $s . "\n");
 

--- a/src/Deployment/PhpsecServer.php
+++ b/src/Deployment/PhpsecServer.php
@@ -20,11 +20,11 @@ class PhpsecServer implements Server
 
 	public function __construct(
 		string $url,
-		string $publicKey = null,
+		?string $publicKey = null,
 		#[\SensitiveParameter]
-		string $privateKey = null,
+		?string $privateKey = null,
 		#[\SensitiveParameter]
-		string $passPhrase = null,
+		?string $passPhrase = null,
 	) {
 		$this->url = parse_url($url);
 		if (!isset($this->url['scheme'], $this->url['user'], $this->url['host']) || $this->url['scheme'] !== 'phpsec') {
@@ -64,7 +64,7 @@ class PhpsecServer implements Server
 	}
 
 
-	public function writeFile(string $local, string $remote, callable $progress = null): void
+	public function writeFile(string $local, string $remote, ?callable $progress = null): void
 	{
 		if ($this->sftp->put($remote, $local, SFTP::SOURCE_LOCAL_FILE, -1, -1, $progress) === false) {
 			throw new ServerException('Unable to write file');
@@ -129,7 +129,7 @@ class PhpsecServer implements Server
 	}
 
 
-	public function purge(string $path, callable $progress = null): void
+	public function purge(string $path, ?callable $progress = null): void
 	{
 		if ($this->sftp->file_exists($path)) {
 			if ($this->sftp->delete($path, true) === false) {

--- a/src/Deployment/RetryServer.php
+++ b/src/Deployment/RetryServer.php
@@ -42,7 +42,7 @@ class RetryServer implements Server
 	}
 
 
-	public function writeFile(string $local, string $remote, callable $progress = null): void
+	public function writeFile(string $local, string $remote, ?callable $progress = null): void
 	{
 		$this->retry(__FUNCTION__, func_get_args());
 	}
@@ -72,7 +72,7 @@ class RetryServer implements Server
 	}
 
 
-	public function purge(string $path, callable $progress = null): void
+	public function purge(string $path, ?callable $progress = null): void
 	{
 		$this->retry(__FUNCTION__, func_get_args());
 	}

--- a/src/Deployment/Safe.php
+++ b/src/Deployment/Safe.php
@@ -89,7 +89,7 @@ class Safe
 
 
 	/** @throws ServerException */
-	public static function exec(string $command, array &$output = null, int &$return_var = null): string
+	public static function exec(string $command, ?array &$output = null, ?int &$return_var = null): string
 	{
 		return self::__callStatic(__FUNCTION__, [$command, &$output, &$return_var]);
 	}

--- a/src/Deployment/Server.php
+++ b/src/Deployment/Server.php
@@ -32,7 +32,7 @@ interface Server
 	 * Uploads file to server. Paths are absolute.
 	 * @throws ServerException
 	 */
-	function writeFile(string $local, string $remote, callable $progress = null): void;
+	function writeFile(string $local, string $remote, ?callable $progress = null): void;
 
 	/**
 	 * Removes file from server if exists. Path is absolute.
@@ -62,7 +62,7 @@ interface Server
 	 * Recursive deletes content of directory or file. Path is absolute.
 	 * @throws ServerException
 	 */
-	function purge(string $path, callable $progress = null): void;
+	function purge(string $path, ?callable $progress = null): void;
 
 	/**
 	 * Changes file permissions. Path is absolute.

--- a/src/Deployment/ServerException.php
+++ b/src/Deployment/ServerException.php
@@ -13,7 +13,7 @@ namespace Deployment;
 
 class ServerException extends \Exception
 {
-	public function __construct(string $message, string $file = null, int $line = null)
+	public function __construct(string $message, ?string $file = null, ?int $line = null)
 	{
 		parent::__construct($message);
 		if ($file) {

--- a/src/Deployment/SshServer.php
+++ b/src/Deployment/SshServer.php
@@ -40,11 +40,11 @@ class SshServer implements Server
 	 */
 	public function __construct(
 		string $url,
-		string $publicKey = null,
+		?string $publicKey = null,
 		#[\SensitiveParameter]
-		string $privateKey = null,
+		?string $privateKey = null,
 		#[\SensitiveParameter]
-		string $passPhrase = null,
+		?string $passPhrase = null,
 	) {
 		if (!extension_loaded('ssh2')) {
 			throw new \Exception('PHP extension SSH2 is not loaded.');
@@ -94,7 +94,7 @@ class SshServer implements Server
 	 * Uploads file to FTP server.
 	 * @throws ServerException
 	 */
-	public function writeFile(string $local, string $remote, callable $progress = null): void
+	public function writeFile(string $local, string $remote, ?callable $progress = null): void
 	{
 		$size = max(filesize($local), 1);
 		$len = 0;
@@ -173,7 +173,7 @@ class SshServer implements Server
 	 * Recursive deletes content of directory or file.
 	 * @throws ServerException
 	 */
-	public function purge(string $dir, callable $progress = null): void
+	public function purge(string $dir, ?callable $progress = null): void
 	{
 		if (!file_exists($path = 'ssh2.sftp://' . (int) $this->sftp . $dir)) {
 			return;


### PR DESCRIPTION
Fixes #173

- bug fix / new feature?   #173
- BC break? no

Project code throws error at PHP 8.4 because code is using Implicitly nullable parameter declarations, see more at  post: [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

This PR fixes errors:

```
Deprecated: Deployment\Logger::log(): Implicitly marking parameter $color as nullable is deprecated, the explicit nullable type must be used instead in C:\Users\....\vendor\dg\ftp-deployment\src\Deployment\Logger.php on line 50
Error: Deployment\CommandLine::parse(): Implicitly marking parameter $args as nullable is deprecated, the explicit nullable type must be used instead in C:\Users\....\vendor\dg\ftp-deployment\src\Deployment\CommandLine.php:70
```